### PR TITLE
od: tcp: reduce source port perturb table size

### DIFF
--- a/net/ipv4/inet_hashtables.c
+++ b/net/ipv4/inet_hashtables.c
@@ -906,12 +906,11 @@ EXPORT_SYMBOL_GPL(inet_bhash2_update_saddr);
  * Note that we use 32bit integers (vs RFC 'short integers')
  * because 2^16 is not a multiple of num_ephemeral and this
  * property might be used by clever attacker.
- * RFC claims using TABLE_LENGTH=10 buckets gives an improvement, though
- * attacks were since demonstrated, thus we use 65536 instead to really
- * give more isolation and privacy, at the expense of 256kB of kernel
- * memory.
+ * RFC claims using TABLE_LENGTH=10 buckets gives an improvement,
+ * we use 256 instead to really give more isolation and
+ * privacy, this only consumes 1 KB of kernel memory.
  */
-#define INET_TABLE_PERTURB_SHIFT 16
+#define INET_TABLE_PERTURB_SHIFT 8
 #define INET_TABLE_PERTURB_SIZE (1 << INET_TABLE_PERTURB_SHIFT)
 static u32 *table_perturb;
 


### PR DESCRIPTION
This reverts commit 4c2c8f03a5ab7cb04ec64724d7d176d00bcc91e5, freeing up 256 KiB of RAM.

Per the kernel mailing list:

> The way it was made here makes it easy to patch the value
> for small systems if needed and leaves the door open
> for a configurable setting in the future
> if that was estimated necessary for certain environments.

https://lore.kernel.org/netdev/20220427081914.GA1724@1wt.eu/